### PR TITLE
modify how array of phone numbers is converted into XML

### DIFF
--- a/lib/Net/SMS/CDYNE.pm
+++ b/lib/Net/SMS/CDYNE.pm
@@ -144,16 +144,10 @@ sub advanced_sms_send {
 
     my @subdoc = ();
     foreach my $num (@$nums){
-        push(@subdoc, 
-            {
-                string => [
-                    {
-                        xmlns => 'http://schemas.microsoft.com/2003/10/Serialization/Arrays',
-                        content => $num,
-                    },
-                ]
-            }
-        );
+        push(@subdoc,  {
+            xmlns => 'http://schemas.microsoft.com/2003/10/Serialization/Arrays',
+            content => $num,
+        });
     }
 
     my $doc = {
@@ -169,7 +163,7 @@ sub advanced_sms_send {
                             AssignedDID => [ delete $args{AssignedDID} ],
                             StatusPostBackURL => [ delete $args{StatusPostBackURL} ],
                             ReferenceID => [ $refid ],
-                            PhoneNumbers => \@subdoc
+                            PhoneNumbers => {string => \@subdoc}
                         },
                     ],
                 },


### PR DESCRIPTION
the PhoneNumbers array was not being converted into the XML structure expected by CDYNE for multiple phone numbers, specifically it would form

```
<PhoneNumbers>
  <string ...>1234456354</string>
</PhoneNumbers>
<PhoneNumbers>
  <string ...>1234456354</string>
</PhoneNumbers>
```

instead of 

```
<PhoneNumbers>
  <string ...>1234456354</string>
  <string ...>1234456354</string>
</PhoneNumbers>
```
